### PR TITLE
Switch genome name lookup to hashmap

### DIFF
--- a/src/skani.rs
+++ b/src/skani.rs
@@ -10,6 +10,7 @@ use skani::params::*;
 use skani::screen;
 
 use concurrent_queue::ConcurrentQueue;
+use std::collections::HashMap;
 
 pub struct SkaniPreclusterer {
     pub threshold: f32,
@@ -44,6 +45,7 @@ fn precluster_skani(
         .collect::<Vec<String>>();
     // Note that sketches is now shuffled!
     let sketches = &file_io::fastx_to_sketches(&fasta_strings, &sketch_params, true);
+    let genome_indices: HashMap<_, _> = genome_fasta_paths.into_iter().enumerate().map(|(index, element)| (element, index)).collect();
 
     // Right now implemented by parallel collection into a queue, and then
     // reprocessed into a BTreeMap. Could potentially be made more efficient by
@@ -78,14 +80,8 @@ fn precluster_skani(
                 let query_name = sketches[j].file_name.clone();
 
                 debug!("Pushing ANI result for {} and {}", ref_name, query_name);
-                let ref_index = genome_fasta_paths
-                    .iter()
-                    .position(|&r| r == ref_name)
-                    .unwrap();
-                let query_index = genome_fasta_paths
-                    .iter()
-                    .position(|&r| r == query_name)
-                    .unwrap();
+                let ref_index = genome_indices.get(&ref_name).unwrap();
+                let query_index = genome_indices.get(&query_name).unwrap();
                 if ani >= threshold {
                     queue
                         .push((ref_index, query_index, ani))
@@ -98,7 +94,7 @@ fn precluster_skani(
 
     let mut to_return = SortedPairGenomeDistanceCache::new();
     while let Ok((i, j, ani)) = queue.pop() {
-        to_return.insert((i, j), Some(ani));
+        to_return.insert((*i, *j), Some(ani));
     }
     debug!("Finished skani.");
 


### PR DESCRIPTION
I had a go, but I can't work out this compiler error:

```
   Compiling galah v0.3.1 (/mnt/hpccs01/home/aroneys/src/galah)
error[E0277]: the trait bound `&&str: Borrow<std::string::String>` is not satisfied
  --> src/skani.rs:83:52
   |
83 |                 let ref_index = genome_indices.get(&ref_sketch.file_name).unwrap();
   |                                                --- ^^^^^^^^^^^^^^^^^^^^^ the trait `Borrow<std::string::String>` is not implemented for `&&str`
   |                                                |
   |                                                required by a bound introduced by this call
   |
   = help: the trait `Borrow<str>` is implemented for `std::string::String`
note: required by a bound in `HashMap::<K, V, S>::get`
  --> /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/collections/hash/map.rs:876:5

error[E0277]: the trait bound `&&str: Borrow<std::string::String>` is not satisfied
  --> src/skani.rs:84:54
   |
84 |                 let query_index = genome_indices.get(&query_name).unwrap();
   |                                                  --- ^^^^^^^^^^^ the trait `Borrow<std::string::String>` is not implemented for `&&str`
   |                                                  |
   |                                                  required by a bound introduced by this call
   |
   = help: the trait `Borrow<str>` is implemented for `std::string::String`
note: required by a bound in `HashMap::<K, V, S>::get`
  --> /rustc/90c541806f23a127002de5b4038be731ba1458ca/library/std/src/collections/hash/map.rs:876:5

For more information about this error, try `rustc --explain E0277`.
error: could not compile `galah` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `galah` (lib test) due to 2 previous errors
```